### PR TITLE
Add error message if kubeconfig is missing or misconfigured 

### DIFF
--- a/src/illuminatio/illuminatio.py
+++ b/src/illuminatio/illuminatio.py
@@ -40,6 +40,7 @@ def cli(incluster):
             logger.error("Internal error: Couldn't load kubeconfig with error: %s", type_error)
             exit(1)
 
+
 @cli.command()
 @click.option('-o', '--outfile', default=None,
               help='Output file to write results to. Format is chosen according to file ending. Supported: YAML, JSON')

--- a/src/illuminatio/illuminatio.py
+++ b/src/illuminatio/illuminatio.py
@@ -31,8 +31,14 @@ def cli(incluster):
     if incluster:
         k8s.config.load_incluster_config()
     else:
-        k8s.config.load_kube_config()
-
+        try:
+            k8s.config.load_kube_config()
+        except k8s.config.ConfigException as config_error:
+            logger.error(config_error)
+            exit(1)
+        except TypeError as type_error:
+            logger.error("Internal error: Couldn't load kubeconfig with error: %s", type_error)
+            exit(1)
 
 @cli.command()
 @click.option('-o', '--outfile', default=None,


### PR DESCRIPTION
Fixes #36

This fix prevents the stacktrace and only outputs the error message. It seems like the Python client for Kubernetes has Bug: if the kubeconfig file is absent it raises an `TypeErrror` instead of an `FileNotFound`