### PR TITLE
Add code coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Illuminatio - The kubernetes network policy validator
 
 [![Build Status](https://travis-ci.org/inovex/illuminatio.svg?branch=master)](https://travis-ci.org/inovex/illuminatio)
+[![codecov](https://codecov.io/gh/inovex/illuminatio/branch/master/graph/badge.svg)](https://codecov.io/gh/inovex/illuminatio)
 
 ![alt text](/logo/logo_small.png)
 


### PR DESCRIPTION
Separated from https://github.com/inovex/illuminatio/pull/74, as the badge won't show anything until https://github.com/inovex/illuminatio/pull/74 is merged. If everything is fine with the badge after merge of https://github.com/inovex/illuminatio/pull/74 this can be merged, too.