### PR TITLE
Make clean up less verbose

### DIFF
--- a/src/illuminatio/cleaner.py
+++ b/src/illuminatio/cleaner.py
@@ -95,7 +95,9 @@ class Cleaner:
             responses.append(resp)
         while self.core_api.list_namespace(label_selector=labels_to_string({CLEANUP_LABEL: cleanup_policy})).items:
             self.logger.debug("Waiting for namespaces %s to be deleted.", namespace_names)
-            time.sleep(2)
+
+        # TODO ugly hack to prevent race conditions when deleting namespaces
+        time.sleep(2)
         return responses
 
     def delete_resource_with_cleanup_policy(self, namespaces, cleanup_policy, method, resource_name):

--- a/src/illuminatio/cleaner.py
+++ b/src/illuminatio/cleaner.py
@@ -60,7 +60,7 @@ class Cleaner:
         """
         Deletes all cluster role bindings matching the given cleanup policy
         """
-        self.logger.info("Deleting CRBs  with cleanup policy %s globally", cleanup_policy)
+        self.logger.debug("Deleting CRDs with cleanup policy %s globally", cleanup_policy)
         res = self.rbac_api.delete_collection_cluster_role_binding(
             label_selector=labels_to_string({CLEANUP_LABEL: cleanup_policy}))
         self.logger.debug(res)
@@ -89,7 +89,7 @@ class Cleaner:
         namespaces = self.core_api.list_namespace(
             label_selector=labels_to_string({CLEANUP_LABEL: cleanup_policy})).items
         namespace_names = [n.metadata.name for n in namespaces]
-        self.logger.info("Deleting namespaces %s with cleanup policy %s", namespace_names, cleanup_policy)
+        self.logger.debug("Deleting namespaces %s with cleanup policy %s", namespace_names, cleanup_policy)
         for namespace in namespaces:
             resp = self.core_api.delete_namespace(namespace.metadata.name, propagation_policy="Background")
             responses.append(resp)
@@ -104,8 +104,8 @@ class Cleaner:
         """
         responses = []
         for namespace in namespaces:
-            self.logger.info("Deleting %s in namespace %s with cleanup policy %s",
-                             resource_name, namespace, cleanup_policy)
+            self.logger.debug("Deleting %s in namespace %s with cleanup policy %s",
+                              resource_name, namespace, cleanup_policy)
             try:
                 resp = method(namespace, label_selector=labels_to_string({CLEANUP_LABEL: cleanup_policy}))
                 responses.append(resp)

--- a/src/illuminatio/illuminatio.py
+++ b/src/illuminatio/illuminatio.py
@@ -242,7 +242,7 @@ def clean(hard):
     apps_api = k8s.client.AppsV1Api()
     rbac_api = k8s.client.RbacAuthorizationV1Api()
     cleaner = Cleaner(core_api, apps_api, rbac_api, LOGGER)
-    # clean up project namespaces, as they cascasde resource deletion
+    # clean up project namespaces, as they cascade resource deletion
     for cleanup_val in clean_up_policies:
         cleaner.clean_up_namespaces_with_cleanup_policy(cleanup_val)
     # clean up resources in remaining ns


### PR DESCRIPTION
Currently when you run `illuminatio clean` it's very verbose (even in small environments):

```bash
Starting cleaning resources with policies ['on-request', 'always']
Deleting namespaces ['illuminatio'] with cleanup policy on-request
Deleting namespaces [] with cleanup policy always
Deleting DS in namespace default with cleanup policy on-request
Deleting DS in namespace development with cleanup policy on-request
Deleting DS in namespace kube-node-lease with cleanup policy on-request
Deleting DS in namespace polaris with cleanup policy on-request
Deleting pod in namespace default with cleanup policy on-request
Deleting pod in namespace development with cleanup policy on-request
Deleting pod in namespace kube-node-lease with cleanup policy on-request
Deleting pod in namespace polaris with cleanup policy on-request
Deleting svc in namespace default with cleanup policy on-request
Deleting svc in namespace development with cleanup policy on-request
Deleting svc in namespace kube-node-lease with cleanup policy on-request
Deleting svc in namespace polaris with cleanup policy on-request
Deleting CfgMap in namespace default with cleanup policy on-request
Deleting CfgMap in namespace development with cleanup policy on-request
Deleting CfgMap in namespace kube-node-lease with cleanup policy on-request
Deleting CfgMap in namespace polaris with cleanup policy on-request
Deleting CRBs  with cleanup policy on-request globally
Deleting SA in namespace default with cleanup policy on-request
Deleting SA in namespace development with cleanup policy on-request
Deleting SA in namespace kube-node-lease with cleanup policy on-request
Deleting SA in namespace polaris with cleanup policy on-request
Deleting DS in namespace default with cleanup policy always
Deleting DS in namespace development with cleanup policy always
Deleting DS in namespace kube-node-lease with cleanup policy always
Deleting DS in namespace polaris with cleanup policy always
Deleting pod in namespace default with cleanup policy always
Deleting pod in namespace development with cleanup policy always
Deleting pod in namespace kube-node-lease with cleanup policy always
Deleting pod in namespace polaris with cleanup policy always
Deleting svc in namespace default with cleanup policy always
Deleting svc in namespace development with cleanup policy always
Deleting svc in namespace kube-node-lease with cleanup policy always
Deleting svc in namespace polaris with cleanup policy always
Deleting CfgMap in namespace default with cleanup policy always
Deleting CfgMap in namespace development with cleanup policy always
Deleting CfgMap in namespace kube-node-lease with cleanup policy always
Deleting CfgMap in namespace polaris with cleanup policy always
Deleting CRBs  with cleanup policy always globally
Deleting SA in namespace default with cleanup policy always
Deleting SA in namespace development with cleanup policy always
Deleting SA in namespace kube-node-lease with cleanup policy always
Deleting SA in namespace polaris with cleanup policy always
Finished cleanUp
```

I would consider most of this as debug log instead of logging it to the `INFO` level.