### PR TITLE
Only start resource generation if test cases are generated

### DIFF
--- a/src/illuminatio/illuminatio.py
+++ b/src/illuminatio/illuminatio.py
@@ -84,6 +84,11 @@ def run(outfile, brief, dry, runner_image, target_image):
     if dry:
         LOGGER.info("Skipping test execution as --dry was set")
         return
+
+    if not cases:
+        LOGGER.info("Skipping resource creation since no test were generated")
+        return
+
     results, test_runtimes, additional_data, resource_creation_time, result_wait_time = execute_tests(cases, orch)
     runtimes["resource-creation"] = resource_creation_time - case_time
     runtimes["result-waiting"] = result_wait_time - resource_creation_time


### PR DESCRIPTION
Fixes: https://github.com/inovex/illuminatio/issues/88

Resources should only be generated if there are some tests cases.