### PR TITLE
Add labels during namespace creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ lint:
 	flake8 --max-line-length 120 src tests
 	pycodestyle --max-line-length=120 --exclude=conf.py ./**/*.py
 	black --check --diff ./src ./tests
+
+fmt:
+	black --diff ./src ./tests

--- a/src/illuminatio/illuminatio.py
+++ b/src/illuminatio/illuminatio.py
@@ -250,7 +250,8 @@ def transform_results(
                 LOGGER.debug("receiver_pod: %s", receiver_pod)
                 LOGGER.debug("mapped_sender_pod: %s", mapped_sender_pod)
                 LOGGER.debug("mapped_receiver_pod: %s", mapped_receiver_pod)
-                LOGGER.debug("raw_results: %s", raw_results)
+                LOGGER.debug("raw_results: %s", json.dumps(raw_results))
+                # FIXME: https://github.com/inovex/illuminatio/issues/98
                 if mapped_port in raw_results[mapped_sender_pod][mapped_receiver_pod]:
                     # fetch all requests from desired ports
                     transformed[sender_pod][receiver_pod][port] = raw_results[

--- a/src/illuminatio/test_orchestrator.py
+++ b/src/illuminatio/test_orchestrator.py
@@ -24,9 +24,8 @@ from illuminatio.util import (
     CLEANUP_LABEL,
     ROLE_LABEL,
     CLEANUP_ALWAYS,
-    CLEANUP_ON_REQUEST,
 )
-from illuminatio.util import rand_port
+from illuminatio.util import rand_port, add_illuminatio_labels
 
 
 def get_container_runtime():
@@ -155,12 +154,10 @@ class NetworkTestOrchestrator:
         """
         Creates a namespace with the according labels
         """
-        # Should we also ensure that the namespace has these labels?
-        if labels:
-            labels = {CLEANUP_LABEL: CLEANUP_ON_REQUEST}
-
         namespace = k8s.client.V1Namespace(
-            metadata=k8s.client.V1ObjectMeta(name=name, labels=labels)
+            metadata=k8s.client.V1ObjectMeta(
+                name=name, labels=add_illuminatio_labels(labels)
+            )
         )
 
         try:

--- a/src/illuminatio/util.py
+++ b/src/illuminatio/util.py
@@ -43,3 +43,12 @@ def rand_port(except_ports=None):
     return choice(
         [port for port in range(max_port_int + 1) if port not in except_ports]
     )
+
+
+def add_illuminatio_labels(labels: dict) -> dict:
+    if labels is None or len(labels) == 0:
+        labels = {}
+
+    labels[CLEANUP_LABEL] = CLEANUP_ON_REQUEST
+
+    return labels

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,10 @@
 import pytest
-from illuminatio.util import rand_port
+from illuminatio.util import (
+    rand_port,
+    add_illuminatio_labels,
+    CLEANUP_LABEL,
+    CLEANUP_ON_REQUEST,
+)
 
 
 def test_randPort_noExceptPorts_returnsInt():
@@ -15,3 +20,16 @@ def test_randPort_allPortsExcept_raisesException():
 def test_randPort_allButOnePortsExcepted_returnsRemainingPort():
     generated = rand_port(except_ports=list(range(65535)))
     assert generated == 65535
+
+
+# from illuminatio.util import INVERTED_ATTRIBUTE_PREFIX
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        (None, {CLEANUP_LABEL: CLEANUP_ON_REQUEST}),
+        ({}, {CLEANUP_LABEL: CLEANUP_ON_REQUEST}),
+        ({"test": "test"}, {"test": "test", CLEANUP_LABEL: CLEANUP_ON_REQUEST}),
+    ],
+)
+def test_add_illuminatio_labels(test_input, expected):
+    assert add_illuminatio_labels(test_input) == expected


### PR DESCRIPTION
During debugging https://github.com/inovex/illuminatio/issues/98 I noticed that the namespace are not created properly:

```bash
$ kubectl get ns --show-labels
NAME                             STATUS   AGE   LABELS
default                          Active   3h    <none>
illuminatio                      Active   3h    <none>
illuminatio-inverted-roleadmin   Active   9m    illuminatio-cleanup=on-request
illuminatio-inverted-staging     Active   9m    illuminatio-cleanup=on-request
kube-public                      Active   3h    <none>
kube-system                      Active   3h    <none>
roleadmin                        Active   9m    illuminatio-cleanup=on-request
staging                          Active   3h    <none>
```

after the patch the labels are applied to the namespaces e.g. `role=admin`:

```bash
$ kubectl get ns --show-labels
NAME                             STATUS   AGE   LABELS
default                          Active   3h    <none>
illuminatio                      Active   3h    <none>
illuminatio-inverted-roleadmin   Active   16s   illuminatio-cleanup=on-request,illuminatio-inverted-role=admin
illuminatio-inverted-staging     Active   16s   illuminatio-cleanup=on-request
kube-public                      Active   3h    <none>
kube-system                      Active   3h    <none>
roleadmin                        Active   16s   illuminatio-cleanup=on-request,role=admin
staging                          Active   3h    <none>
```


