### PR TITLE
Simplify travis file and lint target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ docs/_build/*
 cover/*
 MANIFEST
 kubeconfig
+public

--- a/.pylintrc
+++ b/.pylintrc
@@ -130,7 +130,8 @@ disable=print-statement,
         fixme,
         too-many-locals,
         protected-access,
-        consider-using-set-comprehension
+        consider-using-set-comprehension,
+        bad-continuation
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,8 @@ jobs:
 
       before_script:
       # install dependent binaries
+      - which crictl
+      - sudo crictl --debug info
       - curl --fail -Lo kubectl "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl" && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
       - curl --fail -Lo minikube "https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64" && chmod +x minikube && sudo mv minikube /usr/local/bin/
       - mkdir -p $HOME/.kube $HOME/.minikube

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,8 @@ jobs:
       python: "3.8"
       env:
       - KUBECONFIG="$HOME/.kube/config"
-      - KUBERNETES_VERSION=v1.18.6
+      # TODO upgrade to v1.18.6 or newer
+      - KUBERNETES_VERSION=v1.15.3
       # TODO update to v1.12.1 or newer
       - MINIKUBE_VERSION=v1.3.1
       - CHANGE_MINIKUBE_NONE_USER=true
@@ -84,7 +85,8 @@ jobs:
       env:
       - KUBECONFIG="$HOME/.kube/config"
       - CONTAINERD_VERSION=1.3.4
-      - KUBERNETES_VERSION=v1.18.6
+      # TODO upgrade to v1.18.6 or newer
+      - KUBERNETES_VERSION=v1.15.3
       # TODO update to v1.12.1 or newer
       - MINIKUBE_VERSION=v1.3.1
       - CHANGE_MINIKUBE_NONE_USER=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
-dist: xenial
+dist: bionic
+os: linux
+language: python
 
 jobs:
   include:
     - stage: "Check"
       name: "Validate"
-      sudo: required
-      language: bash
+      language: shell
       before_install:
       - sudo apt-get update
       - sudo apt-get install shellcheck -y
@@ -19,93 +20,40 @@ jobs:
       script: mdl -r "~MD013" .
 
     - stage: "Test"
-      name: "test:pycodestyle:3.6"
-      sudo: required
+      name: "test:lint"
       language: python
       cache: pip
-      python:
-       - "3.6"
+      python: "3.8"
       script:
       - make lint
 
     - stage: "Test"
-      name: "test:pycodestyle:3.7"
-      sudo: required
+      name: "test:unittest"
       language: python
       cache: pip
-      python:
-       - "3.7"
-      script:
-      - make lint
-
-    - stage: "Test"
-      name: "test:pylint:3.6"
-      language: python
-      cache: pip
-      python:
-       - "3.6"
-      script:
-      - pip3 install anybadge==1.1.1 pylint==2.3.0 pylint-exit==1.0.0
-      - pylint --rcfile=.pylintrc --output-format=text src | tee pylint.txt
-      - score=$(sed -n 's/^Your code has been rated at \([-0-9.]*\)\/.*/\1/p' pylint.txt)
-      - echo "Pylint score was $score"
-      - mkdir -p public
-      - mv pylint.txt public/pylint.txt
-      - anybadge --value=$score --file=public/pylint.svg pylint
-
-    - stage: "Test"
-      name: "test:pylint:3.7"
-      language: python
-      cache: pip
-      python:
-       - "3.7"
-      script:
-      - pip3 install anybadge==1.1.1 pylint==2.3.0 pylint-exit==1.0.0
-      - pylint --rcfile=.pylintrc --output-format=text src | tee pylint.txt
-      - score=$(sed -n 's/^Your code has been rated at \([-0-9.]*\)\/.*/\1/p' pylint.txt)
-      - echo "Pylint score was $score"
-      - mkdir -p public
-      - mv pylint.txt public/pylint.txt
-      - anybadge --value=$score --file=public/pylint.svg pylint
-
-    - stage: "Test"
-      name: "test:unittest:3.6"
-      language: python
-      cache: pip
-      python:
-      - "3.6"
-      script:
-      - python setup.py test --addopts="-m 'not e2e' --runslow"
-
-    - stage: "Test"
-      name: "test:unittest:3.7"
-      language: python
-      cache: pip
-      python:
-      - "3.7"
+      python: "3.8"
+      # TODO check if we need this
       before_script:
-      - pip install codecov
+        - pip install codecov
       script:
       - python setup.py test --addopts="-m 'not e2e' --runslow"
-      after_script:
-      - codecov
 
     - stage: e2e
       name: "docker - calico e2e Tests"
-      sudo: required
       language: python
       cache: pip
-      python:
-        - "3.7"
-      # ToDo implement multiple python versions?
+      python: "3.8"
       env:
         - KUBECONFIG="$HOME/.kube/config"
-        - KUBERNETES_VERSION=v1.15.3
-        - MINIKUBE_VERSION=v1.3.1
+        - KUBERNETES_VERSION=v1.18.6
+        - MINIKUBE_VERSION=v1.12.1
         - CHANGE_MINIKUBE_NONE_USER=true
         - MINIKUBE_WANTUPDATENOTIFICATION=false
         - MINIKUBE_WANTREPORTERRORPROMPT=false
         - MINIKUBE_HOME=$HOME
+
+      before_install:
+        - sudo apt-get update && sudo apt-get install -y  conntrack
 
       before_script:
       # install dependent binaries
@@ -128,26 +76,24 @@ jobs:
 
     - stage: e2e
       name: "containerd - calico e2e Tests"
-      sudo: required
       language: python
       cache: pip
-      python:
-        - "3.7"
+      python: "3.8"
       env:
-        - CONTAINERD_VERSION=1.2.6
         - KUBECONFIG="$HOME/.kube/config"
-        - KUBERNETES_VERSION=v1.15.3
-        - MINIKUBE_VERSION=v1.3.1
+        - CONTAINERD_VERSION=1.3.4
+        - KUBERNETES_VERSION=v1.18.6
+        - MINIKUBE_VERSION=v1.12.1
         - CHANGE_MINIKUBE_NONE_USER=true
         - MINIKUBE_WANTUPDATENOTIFICATION=false
         - MINIKUBE_WANTREPORTERRORPROMPT=false
         - MINIKUBE_HOME=$HOME
 
       before_install:
-      # See: https://github.com/containerd/cri/blob/master/docs/installation.md
-      - sudo apt-get update && sudo apt-get install libseccomp2 -y
-      - curl --fail -sLO "https://storage.googleapis.com/cri-containerd-release/cri-containerd-${CONTAINERD_VERSION}.linux-amd64.tar.gz"
-      - sudo tar --no-overwrite-dir -C / -xzf cri-containerd-${CONTAINERD_VERSION}.linux-amd64.tar.gz
+        # See: https://github.com/containerd/cri/blob/master/docs/installation.md
+        - sudo apt-get update && sudo apt-get install -y libseccomp2 conntrack
+        - curl --fail -sLO "https://storage.googleapis.com/cri-containerd-release/cri-containerd-${CONTAINERD_VERSION}.linux-amd64.tar.gz"
+        - sudo tar --no-overwrite-dir -C / -xzf cri-containerd-${CONTAINERD_VERSION}.linux-amd64.tar.gz
 
       before_script:
       # install dependent binaries
@@ -173,7 +119,6 @@ jobs:
     - stage: build
       name: "build images"
       if: (tag IS blank)
-      sudo: required
       services:
         - docker
       script:
@@ -184,7 +129,6 @@ jobs:
     - stage: build
       name: "push latest images"
       if: (branch = master AND NOT type = pull_request)
-      sudo: required
       services:
         - docker
       script:
@@ -198,7 +142,6 @@ jobs:
     - stage: build
       name: "push tagged images"
       if: (tag IS present)
-      sudo: required
       services:
         - docker
       script:
@@ -214,8 +157,7 @@ jobs:
       if: (tag IS blank)
       language: python
       cache: pip
-      python:
-        - "3.7"
+      python: "3.8"
       script:
       - python3 setup.py bdist_wheel
       - pip install -e .
@@ -227,8 +169,7 @@ jobs:
       if: (tag IS present)
       language: python
       cache: pip
-      python:
-        - "3.7"
+      python: "3.8"
       script:
       - python setup.py bdist_wheel
       - pip install twine

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,12 @@ jobs:
       language: python
       cache: pip
       python: "3.8"
-      # TODO check if we need this
       before_script:
       - pip install codecov
       script:
-      - python setup.py test --addopts="-m 'not e2e' --runslow"
+      - coverage run setup.py test --addopts="-m 'not e2e' --runslow"
+      after_success:
+      - codecov
 
     - stage: e2e
       name: "docker - calico e2e Tests"
@@ -72,7 +73,7 @@ jobs:
       # run illuminatio e2e tests
       - ./local_dev/run_e2e_tests.sh
 
-      after_script:
+      after_success:
       - codecov
 
     - stage: e2e
@@ -114,7 +115,7 @@ jobs:
       # run illuminatio e2e tests
       - ./local_dev/run_e2e_tests.sh
 
-      after_script:
+      after_success:
       - codecov
 
     # merely build the image for untagged commits

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
       python: "3.8"
       # TODO check if we need this
       before_script:
-        - pip install codecov
+      - pip install codecov
       script:
       - python setup.py test --addopts="-m 'not e2e' --runslow"
 
@@ -44,16 +44,17 @@ jobs:
       cache: pip
       python: "3.8"
       env:
-        - KUBECONFIG="$HOME/.kube/config"
-        - KUBERNETES_VERSION=v1.18.6
-        - MINIKUBE_VERSION=v1.12.1
-        - CHANGE_MINIKUBE_NONE_USER=true
-        - MINIKUBE_WANTUPDATENOTIFICATION=false
-        - MINIKUBE_WANTREPORTERRORPROMPT=false
-        - MINIKUBE_HOME=$HOME
+      - KUBECONFIG="$HOME/.kube/config"
+      - KUBERNETES_VERSION=v1.18.6
+      # TODO update to v1.12.1 or newer
+      - MINIKUBE_VERSION=v1.3.1
+      - CHANGE_MINIKUBE_NONE_USER=true
+      - MINIKUBE_WANTUPDATENOTIFICATION=false
+      - MINIKUBE_WANTREPORTERRORPROMPT=false
+      - MINIKUBE_HOME=$HOME
 
       before_install:
-        - sudo apt-get update && sudo apt-get install -y  conntrack
+      - sudo apt-get update && sudo apt-get install -y  conntrack
 
       before_script:
       # install dependent binaries
@@ -80,25 +81,24 @@ jobs:
       cache: pip
       python: "3.8"
       env:
-        - KUBECONFIG="$HOME/.kube/config"
-        - CONTAINERD_VERSION=1.3.4
-        - KUBERNETES_VERSION=v1.18.6
-        - MINIKUBE_VERSION=v1.12.1
-        - CHANGE_MINIKUBE_NONE_USER=true
-        - MINIKUBE_WANTUPDATENOTIFICATION=false
-        - MINIKUBE_WANTREPORTERRORPROMPT=false
-        - MINIKUBE_HOME=$HOME
+      - KUBECONFIG="$HOME/.kube/config"
+      - CONTAINERD_VERSION=1.3.4
+      - KUBERNETES_VERSION=v1.18.6
+      # TODO update to v1.12.1 or newer
+      - MINIKUBE_VERSION=v1.3.1
+      - CHANGE_MINIKUBE_NONE_USER=true
+      - MINIKUBE_WANTUPDATENOTIFICATION=false
+      - MINIKUBE_WANTREPORTERRORPROMPT=false
+      - MINIKUBE_HOME=$HOME
 
       before_install:
-        # See: https://github.com/containerd/cri/blob/master/docs/installation.md
-        - sudo apt-get update && sudo apt-get install -y libseccomp2 conntrack
-        - curl --fail -sLO "https://storage.googleapis.com/cri-containerd-release/cri-containerd-${CONTAINERD_VERSION}.linux-amd64.tar.gz"
-        - sudo tar --no-overwrite-dir -C / -xzf cri-containerd-${CONTAINERD_VERSION}.linux-amd64.tar.gz
+      # See: https://github.com/containerd/cri/blob/master/docs/installation.md
+      - sudo apt-get update && sudo apt-get install -y libseccomp2 conntrack
+      - curl --fail -sLO "https://storage.googleapis.com/cri-containerd-release/cri-containerd-${CONTAINERD_VERSION}.linux-amd64.tar.gz"
+      - sudo tar --no-overwrite-dir -C / -xzf cri-containerd-${CONTAINERD_VERSION}.linux-amd64.tar.gz
 
       before_script:
       # install dependent binaries
-      - which crictl
-      - sudo crictl --debug info
       - curl --fail -Lo kubectl "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl" && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
       - curl --fail -Lo minikube "https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64" && chmod +x minikube && sudo mv minikube /usr/local/bin/
       - mkdir -p $HOME/.kube $HOME/.minikube

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
 lint:
-	pip3 install flake8==3.7.7 pycodestyle==2.5.0 black==19.10b0
+	@rm -rf ./public
+	pip3 install flake8==3.7.7 pycodestyle==2.5.0 black==19.10b0 anybadge==1.1.1 pylint==2.5.3 pylint-exit==1.2.0
 	flake8 --max-line-length 120 src tests
 	pycodestyle --max-line-length=120 --exclude=conf.py ./**/*.py
 	black --check --diff ./src ./tests
+	pylint --rcfile=.pylintrc --output-format=text src | tee pylint.txt
+	mkdir -p public
+	anybadge --value=$$(sed -n 's/^Your code has been rated at \([-0-9.]*\)\/.*/\1/p' pylint.txt) --file=public/pylint.svg pylint
+	mv pylint.txt public/pylint.txt
 
 fmt:
 	black --diff ./src ./tests

--- a/local_dev/run_e2e_tests.sh
+++ b/local_dev/run_e2e_tests.sh
@@ -20,7 +20,7 @@ then
   sudo docker pull "${ILLUMINATIO_IMAGE}"
 fi
 
-if ! python setup.py test --addopts="-m e2e";
+if ! coverage run setup.py test --addopts="-m e2e";
 then
   kubectl -n illuminatio get po -o yaml
 fi


### PR DESCRIPTION
Simplify the overcomplicated and verbose travis file to make it easier to maintain it. Also I thing the codecov part is still broken: https://github.com/inovex/illuminatio#illuminatio---the-kubernetes-network-policy-validator the badge alway shows 0.