### PR TITLE
Support test case generation only and upload

### DIFF
--- a/src/illuminatio/test_case.py
+++ b/src/illuminatio/test_case.py
@@ -114,6 +114,16 @@ def merge_in_dict(cases: List[NetworkTestCase]):
     return out
 
 
+def from_merged_dict(dictionary: dict) -> List[NetworkTestCase]:
+    """
+    Converts a dictionary into a list of NetworkTestCases
+    """
+    return [
+        NetworkTestCase.from_stringified_members(f, t, p)
+        for f, t, p in triples_from_dict(dictionary)
+    ]
+
+
 def to_yaml(cases: List[NetworkTestCase]):
     """
     Converts a list of NetworkTestCases into a yaml string
@@ -137,7 +147,4 @@ def from_yaml(yaml_string) -> List[NetworkTestCase]:
     """
     Converts a yaml string into a list of NetworkTestCases
     """
-    return [
-        NetworkTestCase.from_stringified_members(f, t, p)
-        for f, t, p in triples_from_dict(yaml.safe_load(yaml_string))
-    ]
+    return from_merged_dict(yaml.safe_load(yaml_string))

--- a/src/illuminatio/util.py
+++ b/src/illuminatio/util.py
@@ -2,6 +2,13 @@
 Contains several illuminatio constants especially names and some util functions
 """
 from random import choice
+from dataclasses import dataclass
+from functools import partial
+from typing import Callable, Any, IO, Optional
+import os
+import json
+import sys
+import yaml
 
 PROJECT_PREFIX = "illuminatio"
 PROJECT_NAMESPACE = PROJECT_PREFIX
@@ -13,6 +20,82 @@ CLEANUP_ALWAYS = "always"
 CLEANUP_ON_REQUEST = "on-request"
 
 CLEANUP_VALUES = [CLEANUP_ALWAYS, CLEANUP_ON_REQUEST]
+
+STD_IDENTIFIER = "-"
+
+
+@dataclass(repr=False, frozen=True)
+class Format:
+    """
+    A format able to load and dump data.
+    """
+
+    load: Callable[[IO[bytes]], Any]
+    dump: Callable[[Any, IO[str]], None]
+
+
+JSON = Format(json.load, partial(json.dump, indent=2))
+YAML = Format(yaml.safe_load, partial(yaml.safe_dump, default_flow_style=False))
+
+FORMATS = {
+    "json": JSON,
+    "yaml": YAML,
+    "yml": YAML,
+}
+
+
+def open_or_std(file, std, *args, **kwargs):
+    """
+    Opens the file in the specified mode unless file is STD_IDENTIFIER,
+    in which case it returns std.
+    """
+    if file == STD_IDENTIFIER:
+        return std
+    return open(file, *args, **kwargs)
+
+
+def format_for(
+    filename: Optional[str] = None, format_name: Optional[str] = None
+) -> Format:
+    """
+    Obtains the format for the filename and optional explicit format name.
+
+    If the explicit format name is omitted, the filename extension is used as format name.
+    """
+    if not format_name and filename:
+        _, ext = os.path.splitext(filename)
+        format_name = format_name or ext[1:]
+
+    if format_name:
+        fmt = FORMATS.get(format_name)
+    else:
+        fmt = JSON
+
+    if not fmt:
+        raise ValueError("Unknown format %s" % format_name)
+    return fmt
+
+
+def write_formatted(
+    data: Any, filename: str, format_name: Optional[str] = None
+) -> None:
+    """
+    Writes the data to the target file, inferring the format from the filename if not specified explicitly.
+    """
+    fmt = format_for(filename, format_name)
+
+    with open_or_std(filename, sys.stdout, "w") as file:
+        fmt.dump(data, file)
+
+
+def read_formatted(filename: str, format_name: Optional[str] = None) -> Any:
+    """
+    Reads the data from the target file, inferring the format from the filename if not specified explicitly.
+    """
+    fmt = format_for(filename, format_name)
+
+    with open_or_std(filename, sys.stdin, "r") as file:
+        return fmt.load(file)
 
 
 def validate_cleanup_in(labels):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,10 +1,36 @@
 import pytest
+import sys
+import json
 from illuminatio.util import (
     rand_port,
     add_illuminatio_labels,
+    format_for,
+    open_or_std,
+    write_formatted,
+    read_formatted,
     CLEANUP_LABEL,
     CLEANUP_ON_REQUEST,
+    STD_IDENTIFIER,
+    YAML,
+    JSON,
 )
+
+
+@pytest.mark.parametrize(
+    "filename,format_name,expected",
+    [
+        ("foo.yaml", None, YAML),
+        ("foo.yml", None, YAML),
+        ("foo.json", None, JSON),
+        ("foo", None, JSON),
+        ("foo.yaml", "yaml", YAML),
+        ("foo.yaml", "json", JSON),
+        (None, "yaml", YAML),
+        (None, None, JSON),
+    ],
+)
+def test_format_for(filename, format_name, expected):
+    assert format_for(filename, format_name) == expected
 
 
 def test_randPort_noExceptPorts_returnsInt():
@@ -14,6 +40,26 @@ def test_randPort_noExceptPorts_returnsInt():
 def test_randPort_allPortsExcept_raisesException():
     with pytest.raises(Exception):
         rand_port(except_ports=list(range(65535 + 1)))
+
+
+def test_open_or_std(tmp_path):
+    assert open_or_std(STD_IDENTIFIER, sys.stdin) is sys.stdin
+    foo_file = tmp_path / "foo"
+    foo_file.write_text("bar")
+    with open_or_std(foo_file, None) as f1, open(foo_file) as f2:
+        assert f1.read() == f2.read()
+
+
+def test_write_formatted(tmp_path):
+    test_file = tmp_path / "test.json"
+    write_formatted({"foo": "bar"}, test_file)
+    assert test_file.read_text() == json.dumps({"foo": "bar"}, indent=2)
+
+
+def test_read_formatted(tmp_path):
+    test_file = tmp_path / "test.json"
+    test_file.write_text(r'{"foo":"bar"}')
+    assert read_formatted(test_file) == {"foo": "bar"}
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Fixes #90 

Introduce new `generate` command that generates the test cases,
outputting them to a target file.

Add new `-t` / `--test-cases` flag to the `run` command that allows
specifying custom test cases to upload instead of generating.

Add format handling read and write operations. Currently, only
YAML and JSON is supported.

Create and verify tests for obtaining the correct format depending
on the filename and / or an explicit format name.