### PR TITLE
Fix test generation failing for NetworkPolicy ports without port value

### DIFF
--- a/src/illuminatio/test_case.py
+++ b/src/illuminatio/test_case.py
@@ -16,13 +16,12 @@ class NetworkTestCase:
             raise ValueError("fromHost may not be None")
         if to_host is None:
             raise ValueError("toHost may not be None")
-        if on_port is None:
-            raise ValueError("onPort may not be None")
         if should_connect is None:
             raise ValueError("shouldConnect may not be None")
         self.from_host = from_host
         self.to_host = to_host
-        self._on_port = on_port
+        # on_port can be None, which matches all ports
+        self._on_port = on_port if on_port else "*"
         self._should_connect = should_connect
         self.port_string = "%s%s" % (
             ("" if self._should_connect else "-"),

--- a/tests/test_test_generator.py
+++ b/tests/test_test_generator.py
@@ -231,6 +231,81 @@ gen = NetworkTestCaseGenerator(logging.getLogger("test_test_generator"))
             ],
             id="Allow labelled Pods to communicate to Pods with the same labels in the same Namespace",
         ),
+        pytest.param(
+            [k8s.client.V1Namespace(metadata=k8s.client.V1ObjectMeta(name="default"))],
+            [
+                k8s.client.V1NetworkPolicy(
+                    metadata=k8s.client.V1ObjectMeta(
+                        name="allow-labelled-pods", namespace="default"
+                    ),
+                    spec=k8s.client.V1NetworkPolicySpec(
+                        pod_selector=k8s.client.V1LabelSelector(match_labels={}),
+                        ingress=[
+                            k8s.client.V1NetworkPolicyIngressRule(
+                                _from=[
+                                    k8s.client.V1NetworkPolicyPeer(
+                                        pod_selector=k8s.client.V1LabelSelector(
+                                            match_labels={
+                                                "test.io/test-123_XYZ": "test_456-123.ABC"
+                                            }
+                                        )
+                                    )
+                                ],
+                                ports=[
+                                    k8s.client.V1NetworkPolicyPort(
+                                        port=None, protocol="TCP"
+                                    )
+                                ],
+                            )
+                        ],
+                    ),
+                )
+            ],
+            [
+                NetworkTestCase(
+                    ClusterHost(
+                        "default", {"test.io/test-123_XYZ": "test_456-123.ABC"}
+                    ),
+                    ClusterHost("default", {}),
+                    "*",
+                    True,
+                ),
+                NetworkTestCase(
+                    ClusterHost(
+                        "default",
+                        {
+                            INVERTED_ATTRIBUTE_PREFIX
+                            + "test.io/test-123_XYZ": "test_456-123.ABC"
+                        },
+                    ),
+                    ClusterHost("default", {}),
+                    "*",
+                    False,
+                ),
+                NetworkTestCase(
+                    ClusterHost(
+                        INVERTED_ATTRIBUTE_PREFIX + "default",
+                        {"test.io/test-123_XYZ": "test_456-123.ABC"},
+                    ),
+                    ClusterHost("default", {}),
+                    "*",
+                    False,
+                ),
+                NetworkTestCase(
+                    ClusterHost(
+                        INVERTED_ATTRIBUTE_PREFIX + "default",
+                        {
+                            INVERTED_ATTRIBUTE_PREFIX
+                            + "test.io/test-123_XYZ": "test_456-123.ABC"
+                        },
+                    ),
+                    ClusterHost("default", {}),
+                    "*",
+                    False,
+                ),
+            ],
+            id="Correctly handle portless NetworkPolicy",
+        ),
     ],
 )
 def test__generate_test_cases(namespaces, networkpolicies, expected_testcases):


### PR DESCRIPTION
Closes #102 