### PR TITLE
Fix kubeconfig in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ COPY --from=builder /usr/local/bin/illuminatio /usr/local/bin/illuminatio
 COPY --from=builder /usr/local/bin/crictl /usr/local/bin/crictl
 
 ENV PYTHONPATH=/usr/local/lib/python3.8/site-packages
+# Home directory of root user is not recognized when using ~ (default: ~/.kube/config)
+ENV KUBECONFIG=/kubeconfig
 
 # Currently nmap is required for running the scans
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -168,8 +168,10 @@ Instead of installing the `illumnatio` cli on your machine you can also use our 
 You will need to provide the `kubeconfig` to the container and probably some certificates:
 
 ```bash
-docker run -ti -v ~/.kube:/home/illuminatio/.kube:ro inovex/illuminatio illuminatio clean run
+docker run -ti -v ~/.kube/config:/kubeconfig:ro inovex/illuminatio illuminatio clean run
 ```
+
+Please note that some external authentication mechanisms (e.g. GCP / gcloud CLI) don't work correctly inside the container.
 
 ### Minikube
 


### PR DESCRIPTION
Fixes #132 

There were two issues:

-  The example in the README mounted the kubeconfig in the home dir of the "illuminatio" user, but the container runs as root by default, so the default path `~/.kube/config` did not point to the illuminatio home dir. 
- However also the home dir of root `/root` is not resolved correctly, so only explicitly specifying the path using `--kubeconfig` worked.

To fix this issue I've adjusted the README to mount the kubeconfig to `/kubeconfig` and set the `KUBECONFIG` env variable by default in the image.

TODO
- [x] Test if runner runs correctly  -> The e2e tests succeeded.


