### PR TITLE
Implement support for named ports in NetPols

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -20,6 +20,13 @@ Now you can install the illuminatio client:
 python3 setup.py install
 ```
 
+## Debugging using PyCharm
+
+- Add `input("press Enter to continue")` to the `run()` method to block the process
+- Build and start the illuminatio cli in a shell
+- You are now able to attach the Python debugger to the process `Run -> Attach to Process...`
+- Let the client continue and use your breakpoints etc. within PyCharm
+
 ## Local development
 
 We will bootstrap a [Minikube VM](https://kubernetes.io/docs/setup/minikube/) for local development.

--- a/e2e-manifests/15-allow-traffic-to-named-port.yml
+++ b/e2e-manifests/15-allow-traffic-to-named-port.yml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: 15-allow-traffic-to-named-port
+  labels:
+    illuminatio-e2e: 15-allow-traffic-to-named-port
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: 15-allow-traffic-to-named-port
+  labels:
+    app: myfancydeployment
+    role: api
+    illuminatio-e2e: 15-allow-traffic-to-named-port
+  name: my-deployment
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: myfancydeployment
+      role: api
+  template:
+    metadata:
+      labels:
+        app: myfancydeployment
+        role: api
+    spec:
+      containers:
+      - image: nginx
+        imagePullPolicy: Always
+        name: myfancydeployment
+        ports:
+        - containerPort: 80
+          name: mynamedport
+          protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: 15-allow-traffic-to-named-port
+  labels:
+    app: myfancydeployment
+    role: api
+    illuminatio-e2e: 15-allow-traffic-to-named-port
+  name: my-deployment-svc
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: mynamedport
+  selector:
+    app: myfancydeployment
+    role: api
+  type: ClusterIP
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  namespace: 15-allow-traffic-to-named-port
+  name: api-allow
+  labels:
+    illuminatio-e2e: 15-allow-traffic-to-named-port
+spec:
+  podSelector:
+    matchLabels:
+      app: myfancydeployment
+      role: api
+  ingress:
+  - from:
+      - podSelector:
+          matchLabels:
+            role: frontend
+    ports:
+      - port: mynamedport
+        protocol: TCP

--- a/e2e-manifests/expected/15-allow-traffic-to-named-port.yml
+++ b/e2e-manifests/expected/15-allow-traffic-to-named-port.yml
@@ -1,0 +1,16 @@
+15-allow-traffic-to-named-port:illuminatio-inverted-role=frontend:
+  15-allow-traffic-to-named-port:app=myfancydeployment,role=api:
+    -mynamedport:
+      success: true
+15-allow-traffic-to-named-port:role=frontend:
+  15-allow-traffic-to-named-port:app=myfancydeployment,role=api:
+    mynamedport:
+      success: true
+illuminatio-inverted-15-allow-traffic-to-named-port:illuminatio-inverted-role=frontend:
+  15-allow-traffic-to-named-port:app=myfancydeployment,role=api:
+    -mynamedport:
+      success: true
+illuminatio-inverted-15-allow-traffic-to-named-port:role=frontend:
+  15-allow-traffic-to-named-port:app=myfancydeployment,role=api:
+    -mynamedport:
+      success: true

--- a/local_dev/run_e2e_tests.sh
+++ b/local_dev/run_e2e_tests.sh
@@ -22,7 +22,7 @@ while ! docker push "${ILLUMINATIO_IMAGE}" &> /dev/null; do
        echo "Error: could not push image \'${ILLUMINATIO_IMAGE}\" to registry"
        exit 1
   fi
-  echo "Wait for docker regsitry to become ready"
+  echo "Wait for docker registry to become ready"
   counter=$((counter+1))
   sleep 5
 done

--- a/local_dev/start_docker.sh
+++ b/local_dev/start_docker.sh
@@ -11,7 +11,8 @@ minikube start \
     --cni=calico \
     --container-runtime=docker \
     --host-only-cidr=172.17.17.1/24 \
-    --kubernetes-version="${KUBERNETES_VERSION}"
+    --kubernetes-version="${KUBERNETES_VERSION}" \
+    --insecure-registry=localhost:5000
 
 # Setup the minikube docker registry
 minikube addons enable registry

--- a/src/illuminatio/illuminatio.py
+++ b/src/illuminatio/illuminatio.py
@@ -264,6 +264,14 @@ def transform_results(
                 LOGGER.debug("mapped_sender_pod: %s", mapped_sender_pod)
                 LOGGER.debug("mapped_receiver_pod: %s", mapped_receiver_pod)
                 LOGGER.debug("raw_results: %s", json.dumps(raw_results))
+                if mapped_receiver_pod not in raw_results[mapped_sender_pod]:
+                    LOGGER.error(
+                        "No results found for Sender: %s Receiver: %s",
+                        mapped_sender_pod,
+                        mapped_receiver_pod,
+                    )
+                    # TODO handle result
+                    continue
                 # FIXME: https://github.com/inovex/illuminatio/issues/98
                 if mapped_port in raw_results[mapped_sender_pod][mapped_receiver_pod]:
                     # fetch all requests from desired ports

--- a/src/illuminatio/illuminatio_runner.py
+++ b/src/illuminatio/illuminatio_runner.py
@@ -151,6 +151,9 @@ def run_tests_for_sender_pod(sender_pod, cases):
     # TODO check if network ns is None -> HostNetwork is set
     results = {}
     for target, ports in cases[from_host_string].items():
+        if target is None:
+            LOGGER.error("Target is none. Skipping")
+            continue
         start_time = time.time()
         results[target] = run_tests_for_target(network_ns, ports, target)
         runtimes[target] = time.time() - start_time

--- a/src/illuminatio/k8s_util.py
+++ b/src/illuminatio/k8s_util.py
@@ -107,7 +107,9 @@ def create_service_manifest(
     validate_cleanup_in(svc.metadata.labels)
     # TODO: support for other protocols missing, target port might not work like that for multiple ports
     ports = [
-        k8s.client.V1ServicePort(protocol="TCP", port=portNum, target_port=80)
+        k8s.client.V1ServicePort(
+            protocol="TCP", port=portNum, target_port=80, name=f"{portNum}-name"
+        )
         for portNum in port_nums
     ]
     svc.spec.ports = ports

--- a/src/illuminatio/test_orchestrator.py
+++ b/src/illuminatio/test_orchestrator.py
@@ -395,6 +395,8 @@ class NetworkTestOrchestrator:
             resolved_cases[pod_identifier] = {
                 names_per_host[t]: [port_names_per_host[t][p] for p in target_dict[t]]
                 for t in target_dict
+                # TODO This is just a sanity check to not add "None" ipaddresses
+                if names_per_host[t] != "None"
             }
         return resolved_cases, from_host_mappings, to_host_mappings, port_mappings
 

--- a/src/illuminatio/test_orchestrator.py
+++ b/src/illuminatio/test_orchestrator.py
@@ -233,8 +233,12 @@ class NetworkTestOrchestrator:
             )
 
             # Strip of the "-" and add it again after name has been resolved
-            prefix = "-" if "-" in named_port else ""
-            named_port_without_prefix = named_port.replace("-", "")
+            potential_prefix = named_port[0:1]
+            prefix = ""
+            named_port_without_prefix = named_port
+            if potential_prefix == "-":
+                prefix = potential_prefix
+                named_port_without_prefix = named_port[1:]
 
             # We use a simple cache to avoid looking up the same pod-port combination twice for another test case
             key_hostname_port = f"{host_string}_{named_port}"

--- a/src/illuminatio/test_orchestrator.py
+++ b/src/illuminatio/test_orchestrator.py
@@ -17,6 +17,8 @@ from illuminatio.k8s_util import (
     create_service_manifest,
     labels_to_string,
     update_role_binding_manifest,
+    is_numerical_port,
+    resolve_port_name,
 )
 from illuminatio.test_case import merge_in_dict
 from illuminatio.util import (
@@ -72,6 +74,7 @@ class NetworkTestOrchestrator:
         self.current_namespaces = []
         self.runner_daemon_set = None
         self.oci_images = {}
+        self.portname_cache = {}
         self.logger = log
 
     def set_runner_image(self, runner_image):
@@ -171,7 +174,7 @@ class NetworkTestOrchestrator:
             self.logger.error(api_exception)
             exit(1)
 
-    def _rewrite_ports_for_host(self, port_list, services_for_host):
+    def _rewrite_ports_for_host(self, host_string, port_list, services_for_host):
         self.logger.debug("Rewriting portList %s", port_list)
         if not services_for_host:
             # assign random port, a service with matching port will be created
@@ -181,9 +184,12 @@ class NetworkTestOrchestrator:
             }
         rewritten_ports = {}
         wild_card_ports = {p for p in port_list if "*" in p}
-        numbered_ports = {p for p in port_list if "*" not in p}
+        numbered_ports = {p for p in port_list if is_numerical_port(p)}
+        # We assume that the other ports are named_ports
+        named_ports = set(port_list) - set(numbered_ports) - set(wild_card_ports)
         service_ports = [p for svc in services_for_host for p in svc.spec.ports]
         self.logger.debug("Svc ports: %s", service_ports)
+
         for wildcard_port in wild_card_ports:
             prefix = "-" if "-" in wildcard_port else ""
             # choose any port for wildcard
@@ -191,11 +197,15 @@ class NetworkTestOrchestrator:
                 prefix,
                 str(service_ports[0].port),
             )
+
         for port in numbered_ports:
             prefix = "-" if "-" in port else ""
             port_int = int(port.replace("-", ""))
             service_ports_for_port = [
-                p for p in service_ports if p.target_port == port_int
+                p
+                for p in service_ports
+                # TODO Services could also contain named ports. We should cross-compare here (resvoledName == numerical)
+                if p.target_port == port_int
             ]
             # TODO this was a hotfix for recipe 11, where ports 53 were allowed but not for any target,
             # resulting in test to 53 being written despite no service matching them existing.
@@ -208,6 +218,30 @@ class NetworkTestOrchestrator:
             else:
                 # TODO change to exception, handle it higher up
                 rewritten_ports[port] = "err"
+
+        for named_port in named_ports:
+            host_string_separated = str(host_string).split(":")
+            namespace = host_string_separated[0]
+            label_selector_string = (
+                host_string_separated[1] if host_string_separated[1] != "*" else ""
+            )
+
+            # Strip of the "-" and add it again after name has been resolved
+            prefix = "-" if "-" in named_port else ""
+            port_without_prefix = named_port.replace("-", "")
+
+            # We use a simple cache to avoid looking up the same pod-port combination twice for another test case
+            key_hostname_port = f"{host_string}_{named_port}"
+            if key_hostname_port not in self.portname_cache:
+                self.portname_cache[key_hostname_port] = resolve_port_name(
+                    namespace, label_selector_string, port_without_prefix
+                )
+
+            rewritten_ports[named_port] = "%s%d" % (
+                prefix,
+                self.portname_cache[key_hostname_port],
+            )
+
         return rewritten_ports
 
     def _get_target_names_creating_them_if_missing(
@@ -239,7 +273,7 @@ class NetworkTestOrchestrator:
                 host,
             )
             rewritten_ports = self._rewrite_ports_for_host(
-                target_dict[host_string], services_for_host
+                host_string, target_dict[host_string], services_for_host,
             )
             self.logger.debug("Rewritten ports: %s", rewritten_ports)
             port_dict_per_host[host_string] = rewritten_ports
@@ -274,7 +308,7 @@ class NetworkTestOrchestrator:
                 )
                 if isinstance(resp, k8s.client.V1Pod):
                     self.logger.debug(
-                        "Target pod %s created succesfully", resp.metadata.name
+                        "Target pod %s created successfully", resp.metadata.name
                     )
                     self._current_pods.append(resp)
                 else:
@@ -283,7 +317,7 @@ class NetworkTestOrchestrator:
                 if isinstance(resp, k8s.client.V1Service):
                     service_names_per_host[host_string] = resp.spec.cluster_ip
                     self.logger.debug(
-                        "Target svc %s created succesfully", resp.metadata.name
+                        "Target svc %s created successfully", resp.metadata.name
                     )
                     self._current_services.append(resp)
                 else:
@@ -335,7 +369,7 @@ class NetworkTestOrchestrator:
                 resp = api.create_namespaced_pod(dummy.metadata.namespace, dummy)
                 if isinstance(resp, k8s.client.V1Pod):
                     self.logger.debug(
-                        "Dummy pod %s created succesfully", resp.metadata.name
+                        "Dummy pod %s created successfully", resp.metadata.name
                     )
                     pods_for_host = [resp]
                     self._current_pods.append(resp)
@@ -702,7 +736,8 @@ class NetworkTestOrchestrator:
                 resp = api.create_namespaced_service_account(namespace, service_account)
                 if isinstance(resp, k8s.client.V1ServiceAccount):
                     self.logger.debug(
-                        "Succesfully created ServiceAccount for namespace %s", namespace
+                        "Successfully created ServiceAccount for namespace %s",
+                        namespace,
                     )
                 else:
                     self.logger.error(

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -48,12 +48,14 @@ def clean_cluster(core_v1):
     "e2e_test_case",
     [
         "01-deny-all-traffic-to-an-application",
+        "15-allow-traffic-to-named-port",
         "labels-with-all-legal-characters",
         "max-length-labels",
     ],
 )
 @pytest.mark.e2e
 def test__e2e__clean_setup__results_are_expected(e2e_test_case, api_client, apps_v1):
+    print(f"Executing e2e test case {e2e_test_case}")
     # get input and expected from test case name
     input_manifest = E2E_INPUT_MANIFEST.format(e2e_test_case)
     expected_yaml = E2E_EXPECTED_YAML.format(e2e_test_case)

--- a/tests/test_k8s_util.py
+++ b/tests/test_k8s_util.py
@@ -1,0 +1,53 @@
+import pytest
+import kubernetes
+
+from illuminatio.k8s_util import resolve_port_from_candidates, is_numerical_port
+
+
+@pytest.mark.parametrize(
+    "pods,portname,expected_port",
+    [
+        (
+            kubernetes.client.V1PodList(
+                api_version="v1",
+                items=[
+                    kubernetes.client.V1Pod(
+                        spec=kubernetes.client.V1PodSpec(
+                            containers=[
+                                kubernetes.client.V1Container(
+                                    image="nginx",
+                                    name="myfancydeployment",
+                                    ports=[
+                                        kubernetes.client.V1ContainerPort(
+                                            name="mywronlgynamedport",
+                                            container_port=8080,
+                                            protocol="TCP",
+                                        ),
+                                        kubernetes.client.V1ContainerPort(
+                                            name="mynamedport",
+                                            container_port=80,
+                                            protocol="TCP",
+                                        ),
+                                    ],
+                                )
+                            ]
+                        )
+                    )
+                ],
+            ),
+            "mynamedport",
+            80,
+        ),
+    ],
+)
+def test_resolve_port_from_candidates(pods, portname, expected_port):
+    actual_port = resolve_port_from_candidates(pods, portname)
+    assert actual_port == expected_port
+
+
+@pytest.mark.parametrize(
+    "port,expected", [("80", True), ("*", False), (80, True), ("my-named-port", False)],
+)
+def test_is_numerical_port(port, expected):
+    actual = is_numerical_port(port)
+    assert actual == expected

--- a/tests/test_test_generator.py
+++ b/tests/test_test_generator.py
@@ -306,6 +306,93 @@ gen = NetworkTestCaseGenerator(logging.getLogger("test_test_generator"))
             ],
             id="Correctly handle portless NetworkPolicy",
         ),
+        pytest.param(
+            [k8s.client.V1Namespace(metadata=k8s.client.V1ObjectMeta(name="default"))],
+            [
+                k8s.client.V1NetworkPolicy(
+                    metadata=k8s.client.V1ObjectMeta(
+                        name="allow-named-port", namespace="default"
+                    ),
+                    spec=k8s.client.V1NetworkPolicySpec(
+                        pod_selector=k8s.client.V1LabelSelector(
+                            match_labels={
+                                "test.io/test-123_XYZ": "test_456-123.RECEIVER"
+                            }
+                        ),
+                        ingress=[
+                            k8s.client.V1NetworkPolicyIngressRule(
+                                _from=[
+                                    k8s.client.V1NetworkPolicyPeer(
+                                        pod_selector=k8s.client.V1LabelSelector(
+                                            match_labels={
+                                                "test.io/test-123_XYZ": "test_456-123.SENDER"
+                                            }
+                                        )
+                                    )
+                                ],
+                                ports=[
+                                    k8s.client.V1NetworkPolicyPort(
+                                        port="mynamedport", protocol="TCP"
+                                    )
+                                ],
+                            )
+                        ],
+                    ),
+                )
+            ],
+            [
+                NetworkTestCase(
+                    ClusterHost(
+                        "default", {"test.io/test-123_XYZ": "test_456-123.SENDER"}
+                    ),
+                    ClusterHost(
+                        "default", {"test.io/test-123_XYZ": "test_456-123.RECEIVER"}
+                    ),
+                    "mynamedport",
+                    True,
+                ),
+                NetworkTestCase(
+                    ClusterHost(
+                        INVERTED_ATTRIBUTE_PREFIX + "default",
+                        {"test.io/test-123_XYZ": "test_456-123.SENDER"},
+                    ),
+                    ClusterHost(
+                        "default", {"test.io/test-123_XYZ": "test_456-123.RECEIVER"}
+                    ),
+                    "mynamedport",
+                    False,
+                ),
+                NetworkTestCase(
+                    ClusterHost(
+                        "default",
+                        {
+                            INVERTED_ATTRIBUTE_PREFIX
+                            + "test.io/test-123_XYZ": "test_456-123.SENDER"
+                        },
+                    ),
+                    ClusterHost(
+                        "default", {"test.io/test-123_XYZ": "test_456-123.RECEIVER"}
+                    ),
+                    "mynamedport",
+                    False,
+                ),
+                NetworkTestCase(
+                    ClusterHost(
+                        INVERTED_ATTRIBUTE_PREFIX + "default",
+                        {
+                            INVERTED_ATTRIBUTE_PREFIX
+                            + "test.io/test-123_XYZ": "test_456-123.SENDER"
+                        },
+                    ),
+                    ClusterHost(
+                        "default", {"test.io/test-123_XYZ": "test_456-123.RECEIVER"}
+                    ),
+                    "mynamedport",
+                    False,
+                ),
+            ],
+            id="Correctly handle NetworkPolicy with named Port",
+        ),
     ],
 )
 def test__generate_test_cases(namespaces, networkpolicies, expected_testcases):


### PR DESCRIPTION
Fixes #131 

# Changes
Illuminatio will lookup the port name during test case orchestration and will use numerical port by then. Currently the first matched pod/container's port will be used, which should be sufficient for the most cases. Note that there are some cases, which are still not yet covered and could lead to false positives for example (see 2. point in TODOs).

While testing the implementation using https://github.com/cloudogu/k8s-security-demos I have discovered some more issues.
Most of them need further investigation, but I have created some sanity checks (e.g. if =! none) to handle the errors and get at least a result. I will try to split those different related issues into actual issues to have them addressed separately. 

# Implementation
The named ports are printed out as is for the generated test cases, but are resolved later one to numerical ports. This is basically the same approach as for the pod label selectors, which are translated to actual pods or dummy pods.

# TODOs
- [x] Cleanup commits
- [x] Think about the problem that different pods with the same labelset could have ports with different number but equal names. It be nice if we would be able to actually test it, because there could be also some differences between the CNIs in their implementation/support of this "edge case".
-> I will create a followup issue therefore since this requires architectural redesign in some places.
- [x] Unit tests
- [x] e2e test cases
- [ ] Create follow-up issues for the discovered problems
- [x] Check if egress ports can also be specified using a name of a label selected pod + implement if necessary
-> Egress is currently not (fully) supported anway(?), see #65. Since namedports are rarely used in egress policies, I decided to skip this feature for now.